### PR TITLE
Add Stickerify among media-related bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [yt-dlp](https://github.com/yt-dlp/yt-dlp) - Download engine for 1000+ sites. The backbone of most media download bots.
 - [gallery-dl](https://github.com/mikf/gallery-dl) - Download images from galleries and image hosting sites.
 - [Telegram Bot API Server](https://github.com/tdlib/telegram-bot-api) - Self-hosted Bot API server for 2 GB file uploads (vs 50 MB default).
-- [Stickerify](https://github.com/Stickerifier/Stickerify) - Telegram bot to convert medias into the format required to be used as Telegram stickers.
+- [Stickerify](https://github.com/Stickerifier/Stickerify) - Telegram bot to convert media into the format required to be used as Telegram stickers.
 
 ## Group Management
 


### PR DESCRIPTION
## What are you adding?

I documented [Stickerify](https://github.com/Stickerifier/Stickerify), a bot made with modern Java tecnologies and capable of converting images and videos into the format needed to use them as Telegram stickers.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The resource is not a duplicate of an existing entry
- [x] All links are working and accessible
- [x] Each entry has a concise description
- [x] Entries are placed in the correct section
- [x] Formatting matches existing entries
- [x] Libraries/projects are actively maintained (commits within last 12 months)
