### PR TITLE
Add Untether to AI & LLM Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [Gemini Telegram Bot](https://github.com/nichuanfang/gemini-telegram-bot) - Google Gemini integration.
 - [LangChain Telegram Bot](https://github.com/langchain-ai/langchain) - Build conversational AI bots with LangChain.
 - [AskePub](https://github.com/GeiserX/AskePub) - Telegram bot that uses GPT-4o to generate AI study notes from ePub books.
+- [Untether](https://github.com/littlebearapps/untether) - Self-hosted bot that bridges AI coding agents to Telegram with inline keyboards, voice transcription, progress streaming, and file transfer.
 
 ## Developer Tools
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [Gemini Telegram Bot](https://github.com/nichuanfang/gemini-telegram-bot) - Google Gemini integration.
 - [LangChain Telegram Bot](https://github.com/langchain-ai/langchain) - Build conversational AI bots with LangChain.
 - [AskePub](https://github.com/GeiserX/AskePub) - Telegram bot that uses GPT-4o to generate AI study notes from ePub books.
+- [Untether](https://github.com/littlebearapps/untether) - Self-hosted Telegram bridge for running AI coding agents remotely.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the AI & LLM Bots section — a self-hosted, MIT-licensed Telegram bridge for running AI coding agents remotely. Python 3.12+, `uv tool install untether`.