### PR TITLE
Add BotVa to AI & LLM Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [Gemini Telegram Bot](https://github.com/nichuanfang/gemini-telegram-bot) - Google Gemini integration.
 - [LangChain Telegram Bot](https://github.com/langchain-ai/langchain) - Build conversational AI bots with LangChain.
 - [AskePub](https://github.com/GeiserX/AskePub) - Telegram bot that uses GPT-4o to generate AI study notes from ePub books.
+- [BotVa](https://github.com/cohe4ko/BotVa) - Self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination.
 
 ## Developer Tools
 


### PR DESCRIPTION
## Summary

- Adds [BotVa](https://github.com/cohe4ko/BotVa) to the **AI & LLM Bots** section
- BotVa is a self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination
- License: MIT

## Checklist

- [x] Entry follows the existing format
- [x] Link points to a valid GitHub repository
- [x] Project is related to Telegram bots
- [x] Added in alphabetical order within the section