### PR TITLE
Add Cyber Collector — multi-platform video downloader bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [gallery-dl](https://github.com/mikf/gallery-dl) - Download images from galleries and image hosting sites.
 - [Telegram Bot API Server](https://github.com/tdlib/telegram-bot-api) - Self-hosted Bot API server for 2 GB file uploads (vs 50 MB default).
 - [Stickerify](https://github.com/Stickerifier/Stickerify) - Telegram bot to convert media into the format required to be used as Telegram stickers.
+- [Cyber Collector](https://t.me/cybercollectorbot) - Download videos from TikTok (no watermark), Instagram Reels & Stories, YouTube Shorts, X/Twitter and Facebook directly in Telegram.
 - [Jellyfin Telegram Channel Sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) - Syncs Jellyfin user access with Telegram channel membership, automatically disabling accounts when members leave.
 
 ## Group Management


### PR DESCRIPTION
Adds [Cyber Collector](https://t.me/cybercollectorbot) to the **Media & File Bots** section.

**What it does:**
Downloads videos from TikTok (without watermark), Instagram Reels & Stories, YouTube & Shorts, X/Twitter, and Facebook — all directly inside Telegram. No sign-up required, no ads.

**Why it fits here:**
It's a free, actively maintained bot focused entirely on media downloading — a natural fit alongside the other download-related entries in this section. Works by just sending a link, making it one of the most frictionless tools in this category.