### PR TITLE
Add Weight Goal Bot to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) - Relays messages between Telegram channels with configurable delay and batch processing.
 - [Paperless Telegram Bot](https://github.com/GeiserX/paperless-telegram-bot) - Manage Paperless-NGX documents entirely through Telegram: upload, search, tag, and organize.
 - [@moreformbot](https://t.me/moreformbot) - Create forms and surveys, share them with anyone, and collect responses — all inside Telegram.
-- [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Tracks photo-backed weekly weight goals in RU/EN groups with charts and achievements.
+- [Weight Goal Bot](https://t.me/my_weight_goal_bot) - Tracks photo-backed weekly weight goals in English, Russian, and Chinese groups with charts and achievements. [Source](https://github.com/IgorShadurin/weight-telegram-bot).
 
 ## AI & LLM Bots
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) - Relays messages between Telegram channels with configurable delay and batch processing.
 - [Paperless Telegram Bot](https://github.com/GeiserX/paperless-telegram-bot) - Manage Paperless-NGX documents entirely through Telegram: upload, search, tag, and organize.
 - [@moreformbot](https://t.me/moreformbot) - Create forms and surveys, share them with anyone, and collect responses — all inside Telegram.
-- [Weight Goal Bot](https://t.me/my_weight_goal_bot) - Tracks photo-backed weekly weight goals with charts, reminders, 53 achievements, and nine natural localizations. [Apache-2.0 source](https://github.com/IgorShadurin/weight-telegram-bot).
+- [Weight Goal Bot](https://t.me/my_weight_goal_bot) - Tracks photo-backed weight goals with weekly checkpoints, charts, reminders, and achievements. [Apache-2.0 source](https://github.com/IgorShadurin/weight-telegram-bot).
 
 ## AI & LLM Bots
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) - Relays messages between Telegram channels with configurable delay and batch processing.
 - [Paperless Telegram Bot](https://github.com/GeiserX/paperless-telegram-bot) - Manage Paperless-NGX documents entirely through Telegram: upload, search, tag, and organize.
 - [@moreformbot](https://t.me/moreformbot) - Create forms and surveys, share them with anyone, and collect responses — all inside Telegram.
-- [Weight Goal Bot](https://t.me/my_weight_goal_bot) - Tracks photo-backed weekly weight goals in English, Russian, and Chinese groups with charts and achievements. [Source](https://github.com/IgorShadurin/weight-telegram-bot).
+- [Weight Goal Bot](https://t.me/my_weight_goal_bot) - Tracks photo-backed weekly weight goals with charts, reminders, 53 achievements, and nine natural localizations. [Apache-2.0 source](https://github.com/IgorShadurin/weight-telegram-bot).
 
 ## AI & LLM Bots
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [Telegram Delay Channel Cloner](https://github.com/GeiserX/telegram-delay-channel-cloner) - Relays messages between Telegram channels with configurable delay and batch processing.
 - [Paperless Telegram Bot](https://github.com/GeiserX/paperless-telegram-bot) - Manage Paperless-NGX documents entirely through Telegram: upload, search, tag, and organize.
 - [@moreformbot](https://t.me/moreformbot) - Create forms and surveys, share them with anyone, and collect responses — all inside Telegram.
+- [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Tracks photo-backed weekly weight goals in RU/EN groups with charts and achievements.
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
## Summary

Adds [Weight Goal Bot](https://t.me/my_weight_goal_bot) ([source](https://github.com/IgorShadurin/weight-telegram-bot)) to Utility Bots.

I maintain this Apache-2.0-licensed Telegram group bot. Its complete interface is naturally adapted for English, Russian, Chinese, Spanish, Portuguese, German, French, Japanese, and Indonesian; it uses photo-backed weigh-ins and provides weekly checkpoints, progress charts, reminders, and 53 achievements.

## Verification

- [x] The [live bot](https://t.me/my_weight_goal_bot) link resolves.
- [x] The [source repository](https://github.com/IgorShadurin/weight-telegram-bot) is public and licensed under Apache-2.0.
- [x] I searched this repository for an existing duplicate.
- [x] This change follows the required title case, one-sentence description under 120 characters, final period, and bottom placement.