### PR TITLE
Add MyStars FaaS to Payments & Commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [Telegram Stars](https://core.telegram.org/bots/payments-stars) - Telegram's digital currency for in-bot purchases.
 - [Stripe Provider](https://core.telegram.org/bots/payments#supported-payment-providers) - Accept credit card payments via Stripe.
 - [TON Connect](https://docs.ton.org/develop/dapps/ton-connect/overview) - Connect TON wallets to your bot for crypto payments.
+- [MyStars FaaS](https://mystars.tg/docs) - Buy Telegram Stars & Premium for any @username via API, paid in GRAM or USDT on TON.
 
 ## Media & File Bots
 


### PR DESCRIPTION
## What are you adding?

MyStars FaaS — a public API for buying Telegram Stars and Telegram Premium for any @username, paid on-chain in GRAM or USDT on the TON network. Delivery is confirmed via signed webhooks.

Added to Payments & Commerce. The section currently covers the official payment docs, Stars, Stripe and TON Connect, but nothing that actually fulfils a Stars/Premium purchase from a bot — this fills that gap.

Open-source SDKs (MIT): mystars-faas on PyPI, @mystars-tg/faas-sdk on npm. Interactive OpenAPI docs: https://mystars.tg/docs

This supersedes issue #50 — forking was unavailable on our account at the time, so we filed an issue instead. Note the link in that issue is now stale; this PR uses the docs URL.

Disclosure: I maintain these SDKs.

## Checklist

- [x] I have read the contribution guidelines
- [x] The resource is not a duplicate of an existing entry
- [x] All links are working and accessible
- [x] Each entry has a concise description
- [x] Entries are placed in the correct section
- [x] Formatting matches existing entries
- [x] Libraries/projects are actively maintained (commits within last 12 months)