### PR TITLE
Add Nyagram to Java / Kotlin section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 8.0+, Mini Apps, pa
 - [TelegramBots](https://github.com/rubenlagus/TelegramBots) - Java library with Spring Boot integration.
 - [kotlin-telegram-bot](https://github.com/kotlin-telegram-bot/kotlin-telegram-bot) - Kotlin DSL for building bots.
 - [tgbotapi](https://github.com/InsanusMokrassar/ktgbotapi) - Multiplatform Kotlin library with coroutine support.
+- [Nyagram](https://github.com/kaleert/nyagram) - Reactive, type-safe framework for Telegram bots based on Spring Boot 3 and Java 21.
 
 ### C# / .NET
 


### PR DESCRIPTION
Hello! I would like to add Nyagram. It's a modern, reactive Telegram Bot framework built with Spring Boot 3 and Project Loom (Virtual Threads) to replace outdated blocking libraries. It features built-in FSM, routing, and full strict-typing.