### PR TITLE
Update checkout action runtime

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Pin third-party actions to immutable commits for reproducible validation.
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # GitHub only detects a newly added license after it reaches the default
       # branch. Pull requests therefore run every structural rule but defer the


### PR DESCRIPTION
## Summary

- update the pinned `actions/checkout` commit from v4 to v7.0.1
- keep the action immutable while moving validation from Node.js 20 to Node.js 24

## Validation

- verified the v7.0.1 tag resolves to commit `3d3c42e5aac5ba805825da76410c181273ba90b1`
- verified `action.yml` declares `using: node24`
- parsed the workflow YAML
- ran `git diff --check`