### PR TITLE
Add Mitup to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [@ozvuchka_free_bot](https://t.me/ozvuchka_free_bot) - Free Russian text-to-speech: turns text into a voice message with lifelike AI voices, no limits, no ads.
 - [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Open-source bot for photo-backed weight goals, reminders, and progress charts.
 - [@Junction Bot](https://t.me/junction_bot) - Automates channel broadcasts, content aggregation, AI digests, and message copying.
+- [@mitupbot](https://t.me/mitupbot?start=src_awesome) - Open-source bot to organize events and meetups in groups with RSVPs, waiting lists, and timezone-aware reminders.
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
## Resource

- **Name:** Mitup (@mitupbot)
- **Category:** Utility Bots
- **Primary link:** https://t.me/mitupbot
- **Source repository:** https://gitlab.com/meetupbot/mitup-telegram-bot (mirrored at https://github.com/AAraKKe/mitup-telegram-bot)
- **Live bot or service:** https://t.me/mitupbot — docs at https://mitup.social

## Why it belongs

Mitup organizes meetups for Telegram groups without joining the group: you create a meeting in a private chat with the bot, share one card into the group, and it tracks RSVPs, runs a waiting list, and sends each attendee a reminder in their own timezone. Running since 2015, free, no ads, MIT-licensed, translated into six languages by its community. Distinct from broadcast or scheduling utilities in this section: it is a full event RSVP flow that keeps the group chat clean.

## Affiliation

- [x] I maintain, own, or commercially benefit from this resource.
- [ ] I have no affiliation with this resource.

I am the maintainer. The bot is free; optional Patreon support raises usage limits.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The resource is not a duplicate of an existing entry
- [x] All links are working and accessible
- [x] The description is one sentence under 120 characters
- [x] Entries are placed in the correct section
- [x] The entry is appended without reordering existing resources
- [x] The project is maintained or demonstrably stable
- [x] The source repository has a detected license, when applicable
- [x] Claims about features, pricing, and maintenance are verifiable
- [x] The branch is based on the latest `main`