### PR TITLE
Add Hivekeep to AI & LLM Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [LangChain Telegram Bot](https://github.com/langchain-ai/langchain) - Build conversational AI bots with LangChain.
 - [AskePub](https://github.com/GeiserX/AskePub) - Telegram bot that uses GPT-4o to generate AI study notes from ePub books.
 - [Untether](https://github.com/littlebearapps/untether) - Self-hosted Telegram bridge for running AI coding agents remotely.
+- [Hivekeep](https://github.com/MarlBurroW/hivekeep) - Self-hosted platform to run a team of AI agents with persistent memory, reachable as a Telegram bot (also Slack, Discord, Matrix).
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds **Hivekeep** to the list.

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins, and are reachable over Telegram, Slack, Discord and Matrix. Single container (Bun + SQLite).

Repo: https://github.com/MarlBurroW/hivekeep

Disclosure: I am the author of Hivekeep.