### PR TITLE
Add Historical Figures Whisper Bot to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [@ozvuchka_free_bot](https://t.me/ozvuchka_free_bot) - Free Russian text-to-speech: turns text into a voice message with lifelike AI voices, no limits, no ads.
 - [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Open-source bot for photo-backed weight goals, reminders, and progress charts.
 - [@Junction Bot](https://t.me/junction_bot) - Automates channel broadcasts, content aggregation, AI digests, and message copying.
+- [Historical Figures Whisper Bot](https://github.com/jordantete/history_whisper_bot) - Open-source bot serving a daily historical figure with portrait, biography and highlights, localized in English and French.
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
Adds one entry to **Utility Bots**.

- [Historical Figures Whisper Bot](https://github.com/jordantete/history_whisper_bot) - Open-source bot serving a daily historical figure with portrait, biography and highlights, localized in English and French.

**Affiliation:** I am the author and maintainer of this bot. No commercial interest — it is free, ad-free and MIT-licensed.

Checked against the contribution guidelines:

- No duplicate — no existing "history"/"historical" entry in the list.
- Links live: [repo](https://github.com/jordantete/history_whisper_bot) and [@HistoricalFiguresWhisperBot](https://t.me/HistoricalFiguresWhisperBot).
- Maintained — active commits, built on python-telegram-bot 22.8.
- License detected by GitHub: MIT.
- Description is one line, in English, ending with a period.

Happy to move it to a different section or reword the description if you prefer.