### PR TITLE
Add @CaptainPost to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [@ozvuchka_free_bot](https://t.me/ozvuchka_free_bot) - Free Russian text-to-speech: turns text into a voice message with lifelike AI voices, no limits, no ads.
 - [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Open-source bot for photo-backed weight goals, reminders, and progress charts.
 - [@Junction Bot](https://t.me/junction_bot) - Automates channel broadcasts, content aggregation, AI digests, and message copying.
+- [@CaptainPost](https://t.me/CaptainPost_bot) - Routes posts between the Telegram channels you own, with per-route review queues, scheduling, link rewriting and source attribution.
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
Adds **@CaptainPost** to *Utility Bots*.

Routes posts between the Telegram channels you own. Each route carries its own
settings: review before publishing, schedule, link rewriting, and a source
signature appended to syndicated content. It connects through a Telegram user
session rather than only the Bot API, so it also works with channels where
adding a bot as administrator is not possible.

- Bot: https://t.me/CaptainPost_bot
- Website: https://captainpost.pages.dev

Closed-source, free tier available. Terms permit only channels the user owns or
administrates, or sources that granted permission, with attribution.

Sits alongside the existing channel-automation entries in the section and
follows their format.
