### PR TITLE
Add TikTapSaveBot to Media & File Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [Jellyfin Telegram Channel Sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) - Syncs Jellyfin user access with Telegram channel membership, automatically disabling accounts when members leave.
 - [VideoDownloaderBot](https://github.com/Avazbek22/VideoDownloaderBot) - Self-hosted Telegram media downloader with video, original file, and MP3 delivery, plus Docker deployment and rollback.
 - [LinkDownloaderBotForGroups](https://github.com/Avazbek22/LinkDownloaderBotForGroups) - Self-hosted Telegram group bot that turns shared video links into native posts with media reuse and automatic updates.
+- [TikTapSaveBot](https://t.me/TikTapSaveBot) - Downloads TikTok, Instagram and X videos without the watermark, right inside Telegram, including inline mode.
 
 ## Group Management
 


### PR DESCRIPTION
Adds [TikTapSaveBot](https://t.me/TikTapSaveBot), a Telegram bot that downloads TikTok, Instagram and X videos without watermark (HD, inline mode, free tier).

Disclosure: I am the author/maintainer of this bot (per CONTRIBUTING guidelines).
- Live URL: https://t.me/TikTapSaveBot
- Actively maintained (last release 2026-08-04, inline mode + Telegram Stars payments live).
- Format matches existing entries; one-line description under 120 chars.