### PR TITLE
Add Telegram ID & Chat ID Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [Webhook vs Long Polling](https://core.telegram.org/bots/webhooks) - Official comparison and setup guide.
 - [Deploy Telegram Bot to AWS Lambda](https://aws.amazon.com/blogs/compute/) - Serverless deployment walkthrough.
 
+- [Telegram ID & Chat ID Guides](https://am10code.github.io/get-telegram-id/) - Practical guides for finding user, chat, group, and channel IDs.
+
 ## Community
 
 - [@BotTalk](https://t.me/bottalk) - English-speaking bot developer community.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [aiogram 3.x Documentation](https://docs.aiogram.dev/en/latest/) - Full docs for the aiogram Python framework.
 - [Webhook vs Long Polling](https://core.telegram.org/bots/webhooks) - Official comparison and setup guide.
 - [Deploy Telegram Bot to AWS Lambda](https://aws.amazon.com/blogs/compute/) - Serverless deployment walkthrough.
-
 - [Telegram ID & Chat ID Guides](https://am10code.github.io/get-telegram-id/) - Practical guides for finding user, chat, group, and channel IDs.
 
 ## Community


### PR DESCRIPTION
## Summary

- Add Telegram ID & Chat ID Guides to the Tutorials & Guides section.
- Describe the resource as practical documentation for user, chat, group, and channel IDs.

## Affiliation

I maintain and own the submitted documentation project.

## Validation

- Followed the documented list-entry format.
- Added the resource to the end of the relevant section.
- Kept the English description under 120 characters.