### PR TITLE
Add @joba_search_bot and @dnd5char_bot to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [@ozvuchka_free_bot](https://t.me/ozvuchka_free_bot) - Free Russian text-to-speech: turns text into a voice message with lifelike AI voices, no limits, no ads.
 - [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Open-source bot for photo-backed weight goals, reminders, and progress charts.
 - [@Junction Bot](https://t.me/junction_bot) - Automates channel broadcasts, content aggregation, AI digests, and message copying.
+- [@joba_search_bot](https://t.me/joba_search_bot) - Aggregates game-industry job posts from Russian-language Telegram channels.
+- [@dnd5char_bot](https://t.me/dnd5char_bot) - Create and manage D&D 5e characters in Russian, with a Mini App sheet.
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
Adds two bots to Utility Bots:

- [@joba_search_bot](https://t.me/joba_search_bot) - aggregates game-industry job posts from Russian-language Telegram channels.
- [@dnd5char_bot](https://t.me/dnd5char_bot) - create and manage D&D 5e characters, with a Mini App sheet.

**Affiliation disclosure:** I develop and run both bots. Both are live, free and actively maintained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)