### PR TITLE
Add ZakupVarta to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [@ozvuchka_free_bot](https://t.me/ozvuchka_free_bot) - Free Russian text-to-speech: turns text into a voice message with lifelike AI voices, no limits, no ads.
 - [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Open-source bot for photo-backed weight goals, reminders, and progress charts.
 - [@Junction Bot](https://t.me/junction_bot) - Automates channel broadcasts, content aggregation, AI digests, and message copying.
+- [ZakupVarta](https://github.com/vovasik07/zakupvarta) - Open-source Telegram alerts for matching Ukrainian public tenders and material changes.
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
Adds ZakupVarta, an MIT-licensed Node.js Telegram bot that monitors public Prozorro procurement data for matching opportunities and material changes. The live bot and website are linked from the repository.\n\nDisclosure: I own and maintain ZakupVarta and may commercially benefit from its inclusion.