### PR TITLE
Add Aeon to AI & LLM Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [LangChain Telegram Bot](https://github.com/langchain-ai/langchain) - Build conversational AI bots with LangChain.
 - [AskePub](https://github.com/GeiserX/AskePub) - Telegram bot that uses GPT-4o to generate AI study notes from ePub books.
 - [Untether](https://github.com/littlebearapps/untether) - Self-hosted Telegram bridge for running AI coding agents remotely.
+- [Aeon](https://github.com/aeonfun/aeon) - Autonomous AI agent framework that reports to Telegram with interactive buttons and inbound command routing.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adding [Aeon](https://github.com/aeonfun/aeon) under **AI & LLM Bots**.

Aeon is an open-source autonomous AI agent framework (MIT). Telegram is one of its delivery channels: a run reports back to a chat with interactive inline buttons, and inbound commands are routed to the agent from Telegram (both webhook and long-polling paths), so you can drive and approve the agent's work from the chat.

- Repo: https://github.com/aeonfun/aeon
- License: MIT, actively maintained (daily commits)
- Fits this section alongside entries like Untether: it is an AI agent that uses a Telegram bot as its report/control surface, not just a wrapper around a single LLM.

Placed at the end of the AI & LLM Bots section, single entry, formatting matches the surrounding lines. Disclosure: I contribute to this project.