### PR TITLE
Add FlowCastle SDK to Libraries & SDKs (Python, JS/TS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [aiogram](https://github.com/aiogram/aiogram) - Modern async framework built on aiohttp. Fast, middleware-based, great for large bots.
 - [Telethon](https://github.com/LonamiWebs/Telethon) - Full MTProto client (not just Bot API). Access user-level features.
 - [telebot (pyTelegramBotAPI)](https://github.com/eternnoir/pyTelegramBotAPI) - Simple, synchronous library. Good for small bots and beginners.
+- [flowcastle](https://github.com/FlowCastle/flowcastle-sdk) - MIT middleware for aiogram and python-telegram-bot that adds a contact CRM, live chat, broadcasts and conversion analytics (hosted dashboard, free tier).
 
 ### JavaScript / TypeScript
 
@@ -61,6 +62,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [Telegraf](https://github.com/telegraf/telegraf) - Popular Node.js framework with middleware architecture.
 - [node-telegram-bot-api](https://github.com/yagop/node-telegram-bot-api) - Lightweight, promise-based. Good for simple bots.
 - [puregram](https://github.com/nitreojs/puregram) - TypeScript library with powerful context and plugin system.
+- [@flowcastle/grammy](https://github.com/FlowCastle/flowcastle-sdk) - MIT middleware for grammY and Telegraf that adds a contact CRM, live chat, broadcasts and conversion analytics (hosted dashboard, free tier).
 
 ### Go
 


### PR DESCRIPTION
Adds the [FlowCastle SDK](https://github.com/FlowCastle/flowcastle-sdk) to both language subsections of Libraries & SDKs — it is middleware for all four listed frameworks (grammY, Telegraf, aiogram, python-telegram-bot) that connects an existing bot to a dashboard with a contact CRM, live-chat handoff, broadcasts, and conversion analytics. Privacy filtering runs locally in the bot process; ordinary updates never wait on the backend.

**Affiliation disclosure (per your contribution rules):** I am the author and founder of FlowCastle. The SDK is MIT with zero runtime dependencies; the backend is our hosted service with a free tier. Actively maintained (last push this week).

🤖 Generated with [Claude Code](https://claude.com/claude-code)