### PR TITLE
Add DayStep to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [@ozvuchka_free_bot](https://t.me/ozvuchka_free_bot) - Free Russian text-to-speech: turns text into a voice message with lifelike AI voices, no limits, no ads.
 - [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Open-source bot for photo-backed weight goals, reminders, and progress charts.
 - [@Junction Bot](https://t.me/junction_bot) - Automates channel broadcasts, content aggregation, AI digests, and message copying.
+- [DayStep](https://t.me/daystep_walker_bot) - Turns daily step counts into a zombie-survival game with PvP duels and collectible badges.
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
I'm the creator/maintainer of this bot.

DayStep is a Telegram bot that turns daily step tracking into a lightweight survival game — PvP duels, collectible map badges, and cooperative monthly "expeditions" driven by aggregate steps from all players.