### PR TITLE
Add delo_pulse_bot to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [@ozvuchka_free_bot](https://t.me/ozvuchka_free_bot) - Free Russian text-to-speech: turns text into a voice message with lifelike AI voices, no limits, no ads.
 - [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Open-source bot for photo-backed weight goals, reminders, and progress charts.
 - [@Junction Bot](https://t.me/junction_bot) - Automates channel broadcasts, content aggregation, AI digests, and message copying.
+- [@delo_pulse_bot](https://t.me/delo_pulse_bot) - Task control for work groups where one task assigned to several people gives each assignee a separate status, private reminders and their own report, with a Mini App for the calendar and statistics.
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
Adds [@delo_pulse_bot](https://t.me/delo_pulse_bot) to **Utility Bots**.

**What it does.** In a normal group chat, a task given to several people quickly becomes everybody's job and nobody's responsibility. DeloPulse gives each assignee a separate status and asks each one to report, so the card shows who accepted, who is working, who finished and who is late — and the task closes after everyone reports, not after the first "done". Deadlines can be shared or per person; private reminders go only to people who have not reported yet. A Mini App adds the calendar, checklists and statistics. RU/UZ/EN, official Bot API only, free with no member or task limits.

**Disclosure:** I work on DeloPulse. It is a closed-source product, like several existing entries in this section; the site is https://delopulse.com.

Checklist:

- No duplicate: searched the README and existing PRs for `DeloPulse` and `delo_pulse_bot`.
- Links are live and return `200`.
- Format matches the section, description is one line in English ending with a period.
- Single suggestion in this pull request.
