### PR TITLE
Add Vacato (@vacato_bot) to Utility Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [@ozvuchka_free_bot](https://t.me/ozvuchka_free_bot) - Free Russian text-to-speech: turns text into a voice message with lifelike AI voices, no limits, no ads.
 - [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Open-source bot for photo-backed weight goals, reminders, and progress charts.
 - [@Junction Bot](https://t.me/junction_bot) - Automates channel broadcasts, content aggregation, AI digests, and message copying.
+- [@Vacato](https://t.me/vacato_bot) - RDAP domain watchlist alerts when a name looks available (free tier).
 
 ## AI & LLM Bots
 


### PR DESCRIPTION
## Summary
- Add [@Vacato](https://t.me/vacato_bot) under Utility Bots — RDAP domain availability watchlist with Telegram alerts (free tier).
- Affiliation: I maintain Vacato (vacato.io).

## Notes
- Peers: alert-style utility bots such as @RemoteJobRadarBot.
- Not a registrar or drop-catcher — alerts only.