### PR TITLE
Add nightmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The Telegram Bot ecosystem has evolved massively — Bot API 10.x, Mini Apps, pa
 - [LangChain Telegram Bot](https://github.com/langchain-ai/langchain) - Build conversational AI bots with LangChain.
 - [AskePub](https://github.com/GeiserX/AskePub) - Telegram bot that uses GPT-4o to generate AI study notes from ePub books.
 - [Untether](https://github.com/littlebearapps/untether) - Self-hosted Telegram bridge for running AI coding agents remotely.
+- [nightmux](https://github.com/mmr710/nightmux) - Self-hosted bot that attaches to tmux sessions to drive Claude Code, Codex, Gemini, or other terminal coding agents; one forum topic per project.
 
 ## Developer Tools
 


### PR DESCRIPTION
Adds nightmux to AI & LLM Bots.

nightmux attaches to tmux sessions to drive Claude Code, Codex, Gemini, or
other terminal coding agents from Telegram — one forum topic per project,
approvals as tap buttons, holds prompts through a Claude Code usage-limit
lockout and resumes automatically when it resets. Self-hosted, single-file
Python daemon, no dependencies, MIT licensed.

I'm the maintainer of nightmux (disclosing per the contributing guidelines'
affiliation-disclosure requirement).

https://github.com/mmr710/nightmux